### PR TITLE
Close sidebar on resultfocus

### DIFF
--- a/www-develop/css/search-sidebar.css
+++ b/www-develop/css/search-sidebar.css
@@ -33,6 +33,7 @@
     height: 100vh;
     width: 300px;
     top: 60px;
+    z-index: 10;
 }
 
 .item-description {

--- a/www-develop/css/style.css
+++ b/www-develop/css/style.css
@@ -502,7 +502,6 @@ a.close-modal {
 }
 
 .results-container.container {
-    z-index: -1;
     position: relative;
 }
 

--- a/www-develop/js/controller/searchCtrl.ts
+++ b/www-develop/js/controller/searchCtrl.ts
@@ -72,6 +72,10 @@ module Controller {
             }
         }
 
+        focusResult() {
+            this.activeItem = '';
+        }
+
         toggleAccomodation() {
 
             if (typeof this.query.accomodation === "undefined") {

--- a/www-develop/templates/search/search.html
+++ b/www-develop/templates/search/search.html
@@ -1,2 +1,4 @@
-<div ng-include="'templates/search/searchSidebar.html'"></div>
-<div ng-include="'templates/search/searchResult.html'"></div>
+<div ng-controller="SearchCtrl as sc">
+    <div ng-include="'templates/search/searchSidebar.html'"></div>
+    <div ng-include="'templates/search/searchResult.html'"></div>
+</div>

--- a/www-develop/templates/search/searchResult.html
+++ b/www-develop/templates/search/searchResult.html
@@ -1,4 +1,4 @@
-<div class="results-container container" ng-class="{'loading' : src.animateLoading}" ng-controller="SearchResultCtrl as src">
+<div class="results-container container" ng-click="sc.focusResult()" ng-class="{'loading' : src.animateLoading}" ng-controller="SearchResultCtrl as src">
     <div class="row">
         <div class="result col-sm-4" ng-repeat="result in src.results">
 
@@ -12,6 +12,7 @@
             category: {{result.category}}<br/>
             locations: {{result.locations}}<br/>
             pics: {{result.pics}}
+            <a href="http://google.de">google</a>
         </div>
 
     </div>

--- a/www-develop/templates/search/searchSidebar.html
+++ b/www-develop/templates/search/searchSidebar.html
@@ -1,4 +1,4 @@
-<div class="container-sidebar" ng-controller="SearchCtrl as sc">
+<div class="container-sidebar">
     <div class="search-menu">
 
         <div class="item" ng-class="{'item-active': sc.isActive('search')}" >


### PR DESCRIPTION
Add ng-click to the result container to close the sidebar. SearchCtrl is now available in search and result.
